### PR TITLE
Create miasma.yml

### DIFF
--- a/blocklists/miasma.yml
+++ b/blocklists/miasma.yml
@@ -1,0 +1,791 @@
+# FOSSA Miasma Worm Supply Chain Attack Blocklist
+# Source: OSV.dev malicious-packages advisories (MAL-2026-*) cross-referenced with
+#         Microsoft, Wiz, JFrog, SafeDep, StepSecurity, and Sonatype analyses.
+# Attack window: 2026-06-01 (Red Hat scope) through 2026-06-05 (npm + source-repo waves)
+# NOTE: Miasma also has a GitHub source-repo injection arm (123+ repos, e.g. .github/setup.js
+#       droppers + .claude/.gemini/.cursor/.vscode triggers). That arm injects files into
+#       repositories rather than publishing packages, so it cannot be expressed as package
+#       locators and is intentionally NOT in this blocklist. Detect it via IoC/file scanning.
+
+metadata:
+  title: "Miasma Worm Supply Chain Attack Blocklist"
+  attack_name: "Miasma (\"The Spreading Blight\") — Shai-Hulud / Mini Shai-Hulud variant"
+  attack_date: "2026-06-01"
+  detection_date: "2026-06-02"
+  attack_type: "Self-propagating credential-stealing worm (binding.gyp + preinstall hooks)"
+  severity: "critical"
+  confirmed_packages: "87"
+  confirmed_versions: "381"
+  c2_exfil: "Public GitHub dead-drop repos tagged 'Miasma: The Spreading Blight' (windy629, liuende501, HerGomUli)"
+  attribution: "TeamPCP (per Microsoft, Wiz, JFrog, SafeDep, StepSecurity)"
+  sources:
+    - "OSV.dev (MAL-2026-* malicious-packages advisories)"
+    - "Microsoft Security"
+    - "Wiz"
+    - "JFrog Security Research"
+    - "SafeDep"
+    - "StepSecurity"
+
+packages:
+  - locator: npm+@jagreehal/workflow$1.16.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5185)"
+  - locator: npm+@redhat-cloud-services/chrome$2.3.1
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5111)"
+  - locator: npm+@redhat-cloud-services/chrome$2.3.2
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5111)"
+  - locator: npm+@redhat-cloud-services/chrome$2.3.4
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5111)"
+  - locator: npm+@redhat-cloud-services/compliance-client$4.0.3
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5133)"
+  - locator: npm+@redhat-cloud-services/compliance-client$4.0.4
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5133)"
+  - locator: npm+@redhat-cloud-services/compliance-client$4.0.6
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5133)"
+  - locator: npm+@redhat-cloud-services/config-manager-client$5.0.4
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5134)"
+  - locator: npm+@redhat-cloud-services/config-manager-client$5.0.5
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5134)"
+  - locator: npm+@redhat-cloud-services/config-manager-client$5.0.7
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5134)"
+  - locator: npm+@redhat-cloud-services/entitlements-client$4.0.11
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5125)"
+  - locator: npm+@redhat-cloud-services/entitlements-client$4.0.12
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5125)"
+  - locator: npm+@redhat-cloud-services/entitlements-client$4.0.14
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5125)"
+  - locator: npm+@redhat-cloud-services/eslint-config-redhat-cloud-services$3.2.1
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5112)"
+  - locator: npm+@redhat-cloud-services/eslint-config-redhat-cloud-services$3.2.2
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5112)"
+  - locator: npm+@redhat-cloud-services/eslint-config-redhat-cloud-services$3.2.4
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5112)"
+  - locator: npm+@redhat-cloud-services/frontend-components$7.7.2
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5113)"
+  - locator: npm+@redhat-cloud-services/frontend-components$7.7.3
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5113)"
+  - locator: npm+@redhat-cloud-services/frontend-components$7.7.5
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5113)"
+  - locator: npm+@redhat-cloud-services/frontend-components-advisor-components$3.8.2
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5135)"
+  - locator: npm+@redhat-cloud-services/frontend-components-advisor-components$3.8.4
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5135)"
+  - locator: npm+@redhat-cloud-services/frontend-components-advisor-components$3.8.6
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5135)"
+  - locator: npm+@redhat-cloud-services/frontend-components-config$6.11.3
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5126)"
+  - locator: npm+@redhat-cloud-services/frontend-components-config$6.11.4
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5126)"
+  - locator: npm+@redhat-cloud-services/frontend-components-config$6.11.6
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5126)"
+  - locator: npm+@redhat-cloud-services/frontend-components-config-utilities$4.11.2
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5114)"
+  - locator: npm+@redhat-cloud-services/frontend-components-config-utilities$4.11.3
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5114)"
+  - locator: npm+@redhat-cloud-services/frontend-components-config-utilities$4.11.5
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5114)"
+  - locator: npm+@redhat-cloud-services/frontend-components-notifications$6.9.2
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5136)"
+  - locator: npm+@redhat-cloud-services/frontend-components-notifications$6.9.3
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5136)"
+  - locator: npm+@redhat-cloud-services/frontend-components-notifications$6.9.5
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5136)"
+  - locator: npm+@redhat-cloud-services/frontend-components-remediations$4.9.2
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5127)"
+  - locator: npm+@redhat-cloud-services/frontend-components-remediations$4.9.3
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5127)"
+  - locator: npm+@redhat-cloud-services/frontend-components-remediations$4.9.5
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5127)"
+  - locator: npm+@redhat-cloud-services/frontend-components-testing$1.2.1
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5128)"
+  - locator: npm+@redhat-cloud-services/frontend-components-testing$1.2.2
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5128)"
+  - locator: npm+@redhat-cloud-services/frontend-components-testing$1.2.4
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5128)"
+  - locator: npm+@redhat-cloud-services/frontend-components-translations$4.4.1
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5137)"
+  - locator: npm+@redhat-cloud-services/frontend-components-translations$4.4.2
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5137)"
+  - locator: npm+@redhat-cloud-services/frontend-components-translations$4.4.4
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5137)"
+  - locator: npm+@redhat-cloud-services/frontend-components-utilities$7.4.1
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5138)"
+  - locator: npm+@redhat-cloud-services/frontend-components-utilities$7.4.2
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5138)"
+  - locator: npm+@redhat-cloud-services/frontend-components-utilities$7.4.4
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5138)"
+  - locator: npm+@redhat-cloud-services/hcc-feo-mcp$0.3.1
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5129)"
+  - locator: npm+@redhat-cloud-services/hcc-feo-mcp$0.3.2
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5129)"
+  - locator: npm+@redhat-cloud-services/hcc-feo-mcp$0.3.4
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5129)"
+  - locator: npm+@redhat-cloud-services/hcc-kessel-mcp$0.3.1
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5139)"
+  - locator: npm+@redhat-cloud-services/hcc-kessel-mcp$0.3.2
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5139)"
+  - locator: npm+@redhat-cloud-services/hcc-kessel-mcp$0.3.4
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5139)"
+  - locator: npm+@redhat-cloud-services/hcc-pf-mcp$0.6.1
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5140)"
+  - locator: npm+@redhat-cloud-services/hcc-pf-mcp$0.6.2
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5140)"
+  - locator: npm+@redhat-cloud-services/hcc-pf-mcp$0.6.4
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5140)"
+  - locator: npm+@redhat-cloud-services/host-inventory-client$5.0.3
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5141)"
+  - locator: npm+@redhat-cloud-services/host-inventory-client$5.0.4
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5141)"
+  - locator: npm+@redhat-cloud-services/host-inventory-client$5.0.6
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5141)"
+  - locator: npm+@redhat-cloud-services/insights-client$4.0.4
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5142)"
+  - locator: npm+@redhat-cloud-services/insights-client$4.0.5
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5142)"
+  - locator: npm+@redhat-cloud-services/insights-client$4.0.7
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5142)"
+  - locator: npm+@redhat-cloud-services/integrations-client$6.0.4
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5130)"
+  - locator: npm+@redhat-cloud-services/integrations-client$6.0.5
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5130)"
+  - locator: npm+@redhat-cloud-services/integrations-client$6.0.7
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5130)"
+  - locator: npm+@redhat-cloud-services/javascript-clients-shared$2.0.8
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5143)"
+  - locator: npm+@redhat-cloud-services/javascript-clients-shared$2.0.9
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5143)"
+  - locator: npm+@redhat-cloud-services/javascript-clients-shared$2.0.11
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5143)"
+  - locator: npm+@redhat-cloud-services/notifications-client$6.1.4
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5144)"
+  - locator: npm+@redhat-cloud-services/notifications-client$6.1.5
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5144)"
+  - locator: npm+@redhat-cloud-services/notifications-client$6.1.7
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5144)"
+  - locator: npm+@redhat-cloud-services/patch-client$4.0.4
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5145)"
+  - locator: npm+@redhat-cloud-services/patch-client$4.0.5
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5145)"
+  - locator: npm+@redhat-cloud-services/patch-client$4.0.7
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5145)"
+  - locator: npm+@redhat-cloud-services/quickstarts-client$4.0.11
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5115)"
+  - locator: npm+@redhat-cloud-services/quickstarts-client$4.0.12
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5115)"
+  - locator: npm+@redhat-cloud-services/quickstarts-client$4.0.14
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5115)"
+  - locator: npm+@redhat-cloud-services/rbac-client$9.0.3
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5116)"
+  - locator: npm+@redhat-cloud-services/rbac-client$9.0.4
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5116)"
+  - locator: npm+@redhat-cloud-services/rbac-client$9.0.6
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5116)"
+  - locator: npm+@redhat-cloud-services/remediations-client$4.0.4
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5146)"
+  - locator: npm+@redhat-cloud-services/remediations-client$4.0.5
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5146)"
+  - locator: npm+@redhat-cloud-services/remediations-client$4.0.7
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5146)"
+  - locator: npm+@redhat-cloud-services/rule-components$4.7.2
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5117)"
+  - locator: npm+@redhat-cloud-services/rule-components$4.7.3
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5117)"
+  - locator: npm+@redhat-cloud-services/rule-components$4.7.5
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5117)"
+  - locator: npm+@redhat-cloud-services/sources-client$3.0.10
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5131)"
+  - locator: npm+@redhat-cloud-services/sources-client$3.0.11
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5131)"
+  - locator: npm+@redhat-cloud-services/sources-client$3.0.13
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5131)"
+  - locator: npm+@redhat-cloud-services/topological-inventory-client$3.0.10
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5118)"
+  - locator: npm+@redhat-cloud-services/topological-inventory-client$3.0.11
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5118)"
+  - locator: npm+@redhat-cloud-services/topological-inventory-client$3.0.13
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5118)"
+  - locator: npm+@redhat-cloud-services/tsc-transform-imports$1.2.2
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5147)"
+  - locator: npm+@redhat-cloud-services/tsc-transform-imports$1.2.4
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5147)"
+  - locator: npm+@redhat-cloud-services/tsc-transform-imports$1.2.6
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5147)"
+  - locator: npm+@redhat-cloud-services/types$3.6.1
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5119)"
+  - locator: npm+@redhat-cloud-services/types$3.6.2
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5119)"
+  - locator: npm+@redhat-cloud-services/types$3.6.4
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5119)"
+  - locator: npm+@redhat-cloud-services/vulnerabilities-client$2.1.8
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5148)"
+  - locator: npm+@redhat-cloud-services/vulnerabilities-client$2.1.9
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5148)"
+  - locator: npm+@redhat-cloud-services/vulnerabilities-client$2.1.11
+    reason: "Miasma worm — Red Hat @redhat-cloud-services preinstall arm (MAL-2026-5148)"
+  - locator: npm+@vapi-ai/server-sdk$0.11.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5209)"
+  - locator: npm+@vapi-ai/server-sdk$0.11.2
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5209)"
+  - locator: npm+@vapi-ai/server-sdk$1.2.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5209)"
+  - locator: npm+@vapi-ai/server-sdk$1.2.2
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5209)"
+  - locator: npm+ai-sdk-ollama$0.13.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5210)"
+  - locator: npm+ai-sdk-ollama$1.1.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5210)"
+  - locator: npm+ai-sdk-ollama$2.2.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5210)"
+  - locator: npm+ai-sdk-ollama$3.8.5
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5210)"
+  - locator: npm+autotel$2.26.4
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5211)"
+  - locator: npm+autotel$3.4.3
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5211)"
+  - locator: npm+autotel-adapters$0.3.5
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5212)"
+  - locator: npm+autotel-audit$0.1.15
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5213)"
+  - locator: npm+autotel-aws$0.13.10
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5214)"
+  - locator: npm+autotel-backends$2.12.26
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5215)"
+  - locator: npm+autotel-cli$0.8.14
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5216)"
+  - locator: npm+autotel-cloudflare$2.18.16
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5217)"
+  - locator: npm+autotel-devtools$0.1.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5218)"
+  - locator: npm+autotel-devtools$1.0.4
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5218)"
+  - locator: npm+autotel-devtools$2.1.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5218)"
+  - locator: npm+autotel-devtools$3.0.2
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5218)"
+  - locator: npm+autotel-devtools$4.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5218)"
+  - locator: npm+autotel-devtools$5.1.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5218)"
+  - locator: npm+autotel-devtools$6.1.2
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5218)"
+  - locator: npm+autotel-drizzle$0.0.27
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5219)"
+  - locator: npm+autotel-edge$3.16.13
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5220)"
+  - locator: npm+autotel-eventcatalog$1.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5221)"
+  - locator: npm+autotel-eventcatalog$2.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5221)"
+  - locator: npm+autotel-eventcatalog$3.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5221)"
+  - locator: npm+autotel-eventcatalog$4.0.2
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5221)"
+  - locator: npm+autotel-eventcatalog$5.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5221)"
+  - locator: npm+autotel-hono$0.4.26
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5222)"
+  - locator: npm+autotel-mcp$0.1.14
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5223)"
+  - locator: npm+autotel-mcp$2.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5223)"
+  - locator: npm+autotel-mcp$3.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5223)"
+  - locator: npm+autotel-mcp$4.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5223)"
+  - locator: npm+autotel-mcp$5.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5223)"
+  - locator: npm+autotel-mcp$6.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5223)"
+  - locator: npm+autotel-mcp$7.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5223)"
+  - locator: npm+autotel-mcp$8.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5223)"
+  - locator: npm+autotel-mcp$9.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5223)"
+  - locator: npm+autotel-mcp$10.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5223)"
+  - locator: npm+autotel-mcp$11.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5223)"
+  - locator: npm+autotel-mcp$13.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5223)"
+  - locator: npm+autotel-mcp$14.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5223)"
+  - locator: npm+autotel-mcp$15.0.2
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5223)"
+  - locator: npm+autotel-mcp$16.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5223)"
+  - locator: npm+autotel-mcp$17.0.2
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5223)"
+  - locator: npm+autotel-mcp$18.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5223)"
+  - locator: npm+autotel-mcp$19.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5223)"
+  - locator: npm+autotel-mcp$20.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5223)"
+  - locator: npm+autotel-mcp$21.1.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5223)"
+  - locator: npm+autotel-mcp$22.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5223)"
+  - locator: npm+autotel-mcp$23.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5223)"
+  - locator: npm+autotel-mcp$24.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5223)"
+  - locator: npm+autotel-mcp$25.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5223)"
+  - locator: npm+autotel-mcp$26.0.2
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5223)"
+  - locator: npm+autotel-mcp$27.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5223)"
+  - locator: npm+autotel-mcp$28.0.3
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5223)"
+  - locator: npm+autotel-mcp$29.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5223)"
+  - locator: npm+autotel-mcp-instrumentation$29.0.2
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5224)"
+  - locator: npm+autotel-mcp-instrumentation$30.0.5
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5224)"
+  - locator: npm+autotel-mcp-instrumentation$31.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5224)"
+  - locator: npm+autotel-mcp-instrumentation$32.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5224)"
+  - locator: npm+autotel-mcp-instrumentation$33.0.2
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5224)"
+  - locator: npm+autotel-mcp-instrumentation$34.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5224)"
+  - locator: npm+autotel-mongoose$0.0.3
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5225)"
+  - locator: npm+autotel-mongoose$1.0.2
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5225)"
+  - locator: npm+autotel-mongoose$2.0.5
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5225)"
+  - locator: npm+autotel-mongoose$3.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5225)"
+  - locator: npm+autotel-mongoose$4.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5225)"
+  - locator: npm+autotel-mongoose$5.0.2
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5225)"
+  - locator: npm+autotel-mongoose$6.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5225)"
+  - locator: npm+autotel-pact$0.2.2
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5226)"
+  - locator: npm+autotel-pact$1.0.3
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5226)"
+  - locator: npm+autotel-playwright$0.4.32
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5227)"
+  - locator: npm+autotel-plugins$0.19.26
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5228)"
+  - locator: npm+autotel-sentry$0.5.13
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5229)"
+  - locator: npm+autotel-subscribers$4.1.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5230)"
+  - locator: npm+autotel-subscribers$5.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5230)"
+  - locator: npm+autotel-subscribers$6.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5230)"
+  - locator: npm+autotel-subscribers$7.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5230)"
+  - locator: npm+autotel-subscribers$8.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5230)"
+  - locator: npm+autotel-subscribers$9.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5230)"
+  - locator: npm+autotel-subscribers$10.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5230)"
+  - locator: npm+autotel-subscribers$11.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5230)"
+  - locator: npm+autotel-subscribers$12.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5230)"
+  - locator: npm+autotel-subscribers$13.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5230)"
+  - locator: npm+autotel-subscribers$14.1.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5230)"
+  - locator: npm+autotel-subscribers$15.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5230)"
+  - locator: npm+autotel-subscribers$16.0.2
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5230)"
+  - locator: npm+autotel-subscribers$17.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5230)"
+  - locator: npm+autotel-subscribers$18.0.3
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5230)"
+  - locator: npm+autotel-subscribers$19.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5230)"
+  - locator: npm+autotel-subscribers$20.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5230)"
+  - locator: npm+autotel-subscribers$21.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5230)"
+  - locator: npm+autotel-subscribers$22.0.2
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5230)"
+  - locator: npm+autotel-subscribers$23.0.2
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5230)"
+  - locator: npm+autotel-subscribers$24.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5230)"
+  - locator: npm+autotel-subscribers$25.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5230)"
+  - locator: npm+autotel-subscribers$26.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5230)"
+  - locator: npm+autotel-subscribers$27.0.2
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5230)"
+  - locator: npm+autotel-subscribers$28.0.2
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5230)"
+  - locator: npm+autotel-subscribers$29.0.6
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5230)"
+  - locator: npm+autotel-subscribers$30.0.4
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5230)"
+  - locator: npm+autotel-subscribers$31.1.4
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5230)"
+  - locator: npm+autotel-tanstack$1.13.27
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5231)"
+  - locator: npm+autotel-terminal$2.1.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5186)"
+  - locator: npm+autotel-terminal$3.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5186)"
+  - locator: npm+autotel-terminal$4.0.2
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5186)"
+  - locator: npm+autotel-terminal$5.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5186)"
+  - locator: npm+autotel-terminal$6.0.3
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5186)"
+  - locator: npm+autotel-terminal$7.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5186)"
+  - locator: npm+autotel-terminal$8.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5186)"
+  - locator: npm+autotel-terminal$9.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5186)"
+  - locator: npm+autotel-terminal$10.0.2
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5186)"
+  - locator: npm+autotel-terminal$11.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5186)"
+  - locator: npm+autotel-terminal$12.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5186)"
+  - locator: npm+autotel-terminal$13.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5186)"
+  - locator: npm+autotel-terminal$14.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5186)"
+  - locator: npm+autotel-terminal$15.0.2
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5186)"
+  - locator: npm+autotel-terminal$16.0.2
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5186)"
+  - locator: npm+autotel-terminal$17.0.10
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5186)"
+  - locator: npm+autotel-terminal$18.0.4
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5186)"
+  - locator: npm+autotel-terminal$19.0.8
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5186)"
+  - locator: npm+autotel-terminal$20.0.2
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5186)"
+  - locator: npm+autotel-terminal$21.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5186)"
+  - locator: npm+autotel-terminal$22.0.2
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5186)"
+  - locator: npm+autotel-terminal$23.0.3
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5186)"
+  - locator: npm+autotel-vitest$0.4.26
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5232)"
+  - locator: npm+autotel-web$1.12.2
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5233)"
+  - locator: npm+awaitly$1.33.3
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5234)"
+  - locator: npm+awaitly-analyze$0.24.2
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5235)"
+  - locator: npm+awaitly-analyze$1.1.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5235)"
+  - locator: npm+awaitly-analyze$2.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5235)"
+  - locator: npm+awaitly-analyze$3.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5235)"
+  - locator: npm+awaitly-analyze$4.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5235)"
+  - locator: npm+awaitly-analyze$5.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5235)"
+  - locator: npm+awaitly-analyze$6.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5235)"
+  - locator: npm+awaitly-analyze$7.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5235)"
+  - locator: npm+awaitly-analyze$8.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5235)"
+  - locator: npm+awaitly-libsql$0.1.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5236)"
+  - locator: npm+awaitly-libsql$1.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5236)"
+  - locator: npm+awaitly-libsql$2.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5236)"
+  - locator: npm+awaitly-libsql$3.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5236)"
+  - locator: npm+awaitly-libsql$4.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5236)"
+  - locator: npm+awaitly-libsql$5.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5236)"
+  - locator: npm+awaitly-libsql$6.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5236)"
+  - locator: npm+awaitly-libsql$7.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5236)"
+  - locator: npm+awaitly-libsql$8.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5236)"
+  - locator: npm+awaitly-libsql$9.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5236)"
+  - locator: npm+awaitly-libsql$10.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5236)"
+  - locator: npm+awaitly-libsql$11.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5236)"
+  - locator: npm+awaitly-libsql$12.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5236)"
+  - locator: npm+awaitly-libsql$13.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5236)"
+  - locator: npm+awaitly-libsql$14.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5236)"
+  - locator: npm+awaitly-libsql$15.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5236)"
+  - locator: npm+awaitly-libsql$16.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5236)"
+  - locator: npm+awaitly-libsql$17.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5236)"
+  - locator: npm+awaitly-libsql$18.1.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5236)"
+  - locator: npm+awaitly-libsql$19.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5236)"
+  - locator: npm+awaitly-libsql$20.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5236)"
+  - locator: npm+awaitly-libsql$21.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5236)"
+  - locator: npm+awaitly-libsql$22.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5236)"
+  - locator: npm+awaitly-mongo$0.1.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5237)"
+  - locator: npm+awaitly-mongo$1.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5237)"
+  - locator: npm+awaitly-mongo$2.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5237)"
+  - locator: npm+awaitly-mongo$3.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5237)"
+  - locator: npm+awaitly-mongo$4.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5237)"
+  - locator: npm+awaitly-mongo$5.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5237)"
+  - locator: npm+awaitly-mongo$6.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5237)"
+  - locator: npm+awaitly-mongo$7.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5237)"
+  - locator: npm+awaitly-mongo$8.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5237)"
+  - locator: npm+awaitly-mongo$9.1.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5237)"
+  - locator: npm+awaitly-mongo$10.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5237)"
+  - locator: npm+awaitly-mongo$11.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5237)"
+  - locator: npm+awaitly-mongo$12.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5237)"
+  - locator: npm+awaitly-mongo$13.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5237)"
+  - locator: npm+awaitly-mongo$14.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5237)"
+  - locator: npm+awaitly-mongo$15.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5237)"
+  - locator: npm+awaitly-mongo$16.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5237)"
+  - locator: npm+awaitly-mongo$17.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5237)"
+  - locator: npm+awaitly-mongo$18.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5237)"
+  - locator: npm+awaitly-mongo$19.1.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5237)"
+  - locator: npm+awaitly-mongo$20.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5237)"
+  - locator: npm+awaitly-mongo$21.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5237)"
+  - locator: npm+awaitly-mongo$22.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5237)"
+  - locator: npm+awaitly-mongo$23.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5237)"
+  - locator: npm+awaitly-postgres$0.1.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5238)"
+  - locator: npm+awaitly-postgres$1.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5238)"
+  - locator: npm+awaitly-postgres$2.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5238)"
+  - locator: npm+awaitly-postgres$3.0.2
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5238)"
+  - locator: npm+awaitly-postgres$4.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5238)"
+  - locator: npm+awaitly-postgres$5.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5238)"
+  - locator: npm+awaitly-postgres$6.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5238)"
+  - locator: npm+awaitly-postgres$7.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5238)"
+  - locator: npm+awaitly-postgres$8.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5238)"
+  - locator: npm+awaitly-postgres$9.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5238)"
+  - locator: npm+awaitly-postgres$10.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5238)"
+  - locator: npm+awaitly-postgres$11.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5238)"
+  - locator: npm+awaitly-postgres$12.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5238)"
+  - locator: npm+awaitly-postgres$13.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5238)"
+  - locator: npm+awaitly-postgres$14.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5238)"
+  - locator: npm+awaitly-postgres$15.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5238)"
+  - locator: npm+awaitly-postgres$16.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5238)"
+  - locator: npm+awaitly-postgres$17.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5238)"
+  - locator: npm+awaitly-postgres$18.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5238)"
+  - locator: npm+awaitly-postgres$19.1.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5238)"
+  - locator: npm+awaitly-postgres$20.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5238)"
+  - locator: npm+awaitly-postgres$21.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5238)"
+  - locator: npm+awaitly-postgres$22.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5238)"
+  - locator: npm+awaitly-postgres$23.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5238)"
+  - locator: npm+awaitly-visualizer$1.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5239)"
+  - locator: npm+awaitly-visualizer$2.0.2
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5239)"
+  - locator: npm+awaitly-visualizer$3.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5239)"
+  - locator: npm+awaitly-visualizer$4.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5239)"
+  - locator: npm+awaitly-visualizer$5.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5239)"
+  - locator: npm+awaitly-visualizer$6.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5239)"
+  - locator: npm+awaitly-visualizer$7.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5239)"
+  - locator: npm+awaitly-visualizer$8.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5239)"
+  - locator: npm+awaitly-visualizer$9.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5239)"
+  - locator: npm+awaitly-visualizer$10.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5239)"
+  - locator: npm+awaitly-visualizer$11.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5239)"
+  - locator: npm+awaitly-visualizer$12.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5239)"
+  - locator: npm+awaitly-visualizer$13.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5239)"
+  - locator: npm+awaitly-visualizer$14.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5239)"
+  - locator: npm+awaitly-visualizer$15.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5239)"
+  - locator: npm+awaitly-visualizer$16.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5239)"
+  - locator: npm+awaitly-visualizer$17.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5239)"
+  - locator: npm+awaitly-visualizer$18.1.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5239)"
+  - locator: npm+awaitly-visualizer$19.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5239)"
+  - locator: npm+awaitly-visualizer$20.0.2
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5239)"
+  - locator: npm+awaitly-visualizer$21.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5239)"
+  - locator: npm+awaitly-visualizer$22.0.2
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5239)"
+  - locator: npm+effect-analyzer$0.3.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5245)"
+  - locator: npm+eslint-plugin-awaitly$0.17.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5246)"
+  - locator: npm+eslint-plugin-awaitly$1.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5246)"
+  - locator: npm+eslint-plugin-executable-stories-jest$1.2.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5247)"
+  - locator: npm+eslint-plugin-executable-stories-jest$2.1.8
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5247)"
+  - locator: npm+eslint-plugin-executable-stories-playwright$1.2.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5248)"
+  - locator: npm+eslint-plugin-executable-stories-playwright$2.1.8
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5248)"
+  - locator: npm+eslint-plugin-executable-stories-vitest$1.2.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5249)"
+  - locator: npm+eslint-plugin-executable-stories-vitest$2.1.8
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5249)"
+  - locator: npm+executable-stories-cypress$3.1.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5250)"
+  - locator: npm+executable-stories-cypress$4.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5250)"
+  - locator: npm+executable-stories-cypress$5.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5250)"
+  - locator: npm+executable-stories-cypress$6.1.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5250)"
+  - locator: npm+executable-stories-cypress$7.0.3
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5250)"
+  - locator: npm+executable-stories-cypress$8.3.2
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5250)"
+  - locator: npm+executable-stories-demo$0.1.11
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5251)"
+  - locator: npm+executable-stories-formatters$0.11.2
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5252)"
+  - locator: npm+executable-stories-init$0.1.2
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5253)"
+  - locator: npm+executable-stories-jest$3.1.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5254)"
+  - locator: npm+executable-stories-jest$4.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5254)"
+  - locator: npm+executable-stories-jest$5.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5254)"
+  - locator: npm+executable-stories-jest$6.1.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5254)"
+  - locator: npm+executable-stories-jest$7.0.3
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5254)"
+  - locator: npm+executable-stories-jest$8.3.2
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5254)"
+  - locator: npm+executable-stories-mcp$0.3.3
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5255)"
+  - locator: npm+executable-stories-playwright$3.1.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5256)"
+  - locator: npm+executable-stories-playwright$4.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5256)"
+  - locator: npm+executable-stories-playwright$5.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5256)"
+  - locator: npm+executable-stories-playwright$6.1.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5256)"
+  - locator: npm+executable-stories-playwright$7.0.3
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5256)"
+  - locator: npm+executable-stories-playwright$8.4.3
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5256)"
+  - locator: npm+executable-stories-react$0.1.7
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5257)"
+  - locator: npm+executable-stories-vitest$2.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5258)"
+  - locator: npm+executable-stories-vitest$3.1.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5258)"
+  - locator: npm+executable-stories-vitest$4.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5258)"
+  - locator: npm+executable-stories-vitest$5.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5258)"
+  - locator: npm+executable-stories-vitest$6.1.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5258)"
+  - locator: npm+executable-stories-vitest$7.0.3
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5258)"
+  - locator: npm+executable-stories-vitest$8.3.3
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5258)"
+  - locator: npm+mountly$0.2.2
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5260)"
+  - locator: npm+mountly-tailwind$0.1.3
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5261)"
+  - locator: npm+node-env-resolver$6.5.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5262)"
+  - locator: npm+node-env-resolver-aws$9.1.2
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5263)"
+  - locator: npm+node-env-resolver-aws$10.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5263)"
+  - locator: npm+node-env-resolver-aws$11.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5263)"
+  - locator: npm+node-env-resolver-aws$12.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5263)"
+  - locator: npm+node-env-resolver-dotenvx$1.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5264)"
+  - locator: npm+node-env-resolver-dotenvx$2.0.1
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5264)"
+  - locator: npm+node-env-resolver-nextjs$7.4.2
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5265)"
+  - locator: npm+node-env-resolver-vite$2.4.2
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5266)"
+  - locator: npm+wrangler-deploy$1.5.5
+    reason: "Miasma worm — npm binding.gyp arm (MAL-2026-5267)"


### PR DESCRIPTION
**Add Miasma worm supply-chain attack blocklist**

## Summary
Adds `blocklists/miasma.yml` covering the **Miasma worm** (a.k.a. "Miasma: The Spreading Blight"), the June 2026 Shai-Hulud / Mini Shai-Hulud variant attributed to TeamPCP. Blocks **381 malicious versions across 87 npm packages** spanning both package-publishing arms of the campaign.

## What's included
| Arm | Packages | Versions |
|---|---|---|
| npm `binding.gyp` worm (node-gyp install-time execution) | 55 | 285 |
| Red Hat `@redhat-cloud-services` `preinstall`-hook arm | 32 | 96 |

Format matches the existing `mini-shai-hulud.yml` schema (`metadata` block + `packages:` list of `locator` / `reason`). Each entry is traceable to its OSV `MAL-2026-*` advisory in the `reason` field.

## Data sourcing & methodology
- **Every version is pulled directly from OSV.dev** (`MAL-2026-*` malicious-packages advisories) — none are hand-typed or inferred.
- Package names enumerated from the authoritative writeups (Microsoft, Wiz, JFrog, SafeDep, StepSecurity), then versions resolved via the OSV API.
- npm-arm entries are included only when the advisory text confirms Miasma; Red Hat-arm entries are the 32 `@redhat-cloud-services/*` packages with 2026-06-02 advisories.

## Deliberately excluded (not silently dropped)
- `http-uploader-dev` — has an advisory (`MAL-2026-4580`) but belongs to a **different campaign**, not Miasma.
- `@evolvconsulting/evolv-coder-lite` — named in one writeup but **no OSV advisory** exists to confirm affected versions.

## Out of scope
Miasma's **third arm** is GitHub source-repo injection (123+ repos planting `.github/setup.js` droppers + `.claude`/`.gemini`/`.cursor`/`.vscode` triggers). It injects files into repos rather than publishing packages, so it **cannot be expressed as package locators** and is intentionally omitted — documented in the file header. It requires IoC/file-based detection, not an SCA blocklist.

## Verification
- `miasma.yml` parses as valid YAML; `metadata.confirmed_packages` (87) and `confirmed_versions` (381) match the actual entry count.
- 381 distinct locators, no duplicates.

## Sources
- OSV.dev (`MAL-2026-*`)
- [Microsoft Security — Red Hat npm Miasma campaign](https://www.microsoft.com/en-us/security/blog/2026/06/02/preinstall-persistence-inside-red-hat-npm-miasma-credential-stealing-campaign/)
- [Wiz — Miasma: Supply Chain Attack Targeting RedHat npm Packages](https://www.wiz.io/blog/miasma-supply-chain-attack-targeting-redhat-npm-packages)
- [SafeDep — Miasma worm AI coding agent config injection](https://safedep.io/miasma-worm-ai-coding-agent-config-injection/)
- StepSecurity — binding.gyp npm supply-chain worm

🤖 Generated with [Claude Code](https://claude.com/claude-code)
